### PR TITLE
Fixing PropTypes for React 16.

### DIFF
--- a/es/Digit.js
+++ b/es/Digit.js
@@ -1,5 +1,6 @@
 var _styles;
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import injectSheet from 'react-jss';
 
@@ -29,9 +30,9 @@ var Digit = function Digit(_ref) {
 };
 
 process.env.NODE_ENV !== "production" ? Digit.propTypes = {
-  digit: React.PropTypes.string.isRequired,
-  speed: React.PropTypes.number.isRequired,
-  animate: React.PropTypes.bool
+  digit: PropTypes.string.isRequired,
+  speed: PropTypes.number.isRequired,
+  animate: PropTypes.bool
 } : void 0;
 
 var styles = (_styles = {

--- a/es/Odometer.js
+++ b/es/Odometer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Digit from './Digit';
 import injectSheet from 'react-jss';
@@ -33,10 +34,10 @@ var Odometer = function Odometer(_ref) {
 };
 
 process.env.NODE_ENV !== "production" ? Odometer.propTypes = {
-  number: React.PropTypes.number.isRequired,
-  digits: React.PropTypes.number,
-  speed: React.PropTypes.number,
-  size: React.PropTypes.number
+  number: PropTypes.number.isRequired,
+  digits: PropTypes.number,
+  speed: PropTypes.number,
+  size: PropTypes.number
 } : void 0;
 
 var styles = {

--- a/lib/Digit.js
+++ b/lib/Digit.js
@@ -4,6 +4,10 @@ exports.__esModule = true;
 
 var _styles;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -40,9 +44,9 @@ var Digit = function Digit(_ref) {
 };
 
 process.env.NODE_ENV !== "production" ? Digit.propTypes = {
-  digit: _react2.default.PropTypes.string.isRequired,
-  speed: _react2.default.PropTypes.number.isRequired,
-  animate: _react2.default.PropTypes.bool
+  digit: _propTypes2.default.string.isRequired,
+  speed: _propTypes2.default.number.isRequired,
+  animate: _propTypes2.default.bool
 } : void 0;
 
 var styles = (_styles = {

--- a/lib/Odometer.js
+++ b/lib/Odometer.js
@@ -2,6 +2,10 @@
 
 exports.__esModule = true;
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -47,10 +51,10 @@ var Odometer = function Odometer(_ref) {
 };
 
 process.env.NODE_ENV !== "production" ? Odometer.propTypes = {
-  number: _react2.default.PropTypes.number.isRequired,
-  digits: _react2.default.PropTypes.number,
-  speed: _react2.default.PropTypes.number,
-  size: _react2.default.PropTypes.number
+  number: _propTypes2.default.number.isRequired,
+  digits: _propTypes2.default.number,
+  speed: _propTypes2.default.number,
+  size: _propTypes2.default.number
 } : void 0;
 
 var styles = {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "peerDependencies": {
     "react": "15.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel-jest": "^19.0.0",
     "enzyme": "^2.7.1",

--- a/src/Digit.js
+++ b/src/Digit.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import injectSheet from 'react-jss'
 
@@ -20,9 +21,9 @@ const Digit = ({digit, animate, speed, classes}) => {
 }
 
 Digit.propTypes = {
-  digit: React.PropTypes.string.isRequired,
-  speed: React.PropTypes.number.isRequired,
-  animate: React.PropTypes.bool,
+  digit: PropTypes.string.isRequired,
+  speed: PropTypes.number.isRequired,
+  animate: PropTypes.bool,
 }
 
 const styles = {

--- a/src/Odometer.js
+++ b/src/Odometer.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Digit from './Digit'
 import injectSheet from 'react-jss'
@@ -25,10 +26,10 @@ const Odometer = ({number, digits = 4, speed = 100, size = 72, classes}) => {
 }
 
 Odometer.propTypes = {
-  number: React.PropTypes.number.isRequired,
-  digits: React.PropTypes.number,
-  speed: React.PropTypes.number,
-  size: React.PropTypes.number
+  number: PropTypes.number.isRequired,
+  digits: PropTypes.number,
+  speed: PropTypes.number,
+  size: PropTypes.number
 }
 
 const styles = {


### PR DESCRIPTION
Hei,

I wanted to try your library with React 16.0.0-beta.5 so I updated it because accessing PropTypes via the main React package has been removed in React v16.0.